### PR TITLE
kube-router CNI hostPath fix

### DIFF
--- a/deploy-sdn/kube-router/kube-router.yaml
+++ b/deploy-sdn/kube-router/kube-router.yaml
@@ -69,7 +69,7 @@ spec:
           path: /lib/modules
         name: lib-modules
       - hostPath:
-          path: /etc/kubernetes/cni/net.d
+          path: /etc/cni/net.d
         name: cni
       - name: kubeconfig
         hostPath:

--- a/deploy-sdn/kube-router/kube-router.yaml
+++ b/deploy-sdn/kube-router/kube-router.yaml
@@ -65,12 +65,12 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:
-      - hostPath:
+      - name: lib-modules
+        hostPath:
           path: /lib/modules
-        name: lib-modules
-      - hostPath:
+      - name: cni
+        hostPath:
           path: /etc/cni/net.d
-        name: cni
       - name: kubeconfig
         hostPath:
           path: /etc/kubernetes/kubeconfig


### PR DESCRIPTION
I'll try to test this tomorrow, but this should fix the kube-router issues mentioned in #1.

This fixes kube-router looking in the wrong host directory for CNI configuration files.